### PR TITLE
Cast BIT fields to boolean only if length is 1

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -32,7 +32,7 @@ export const typeCast = (field, next) => {
     case 'TINY':
       return field.length === 1 ? field.string() === '1' : next();
     case 'BIT':
-      return field.buffer()[0] === 1;
+      return field.length === 1 ? field.buffer()[0] === 1 : field.buffer()[0];
     default:
       return next();
   }


### PR DESCRIPTION
I've been experiencing weird behavior where my column with bit flags was returning booleans where I expected it to return an integer instead. I think after my commit this will be less confusing :). I don't think default behaviour should discard data like it does now.