### PR TITLE
feat(logger): Option to change command name

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,7 @@ export const mysql_debug = GetConvar('mysql_debug', 'false') === 'true';
 export const mysql_ui = GetConvar('mysql_ui', 'false') === 'true';
 export const mysql_slow_query_warning = GetConvarInt('mysql_slow_query_warning', 200);
 export const mysql_connection_string = GetConvar('mysql_connection_string', '');
+export const mysql_ui_command = GetConvar('mysql_ui_command', 'mysql');
 
 export const mysql_transaction_isolation_level = (() => {
   const query = 'SET TRANSACTION ISOLATION LEVEL';

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,4 +1,4 @@
-import { mysql_debug, mysql_slow_query_warning, mysql_ui } from '../config';
+import { mysql_debug, mysql_slow_query_warning, mysql_ui, mysql_ui_command } from '../config';
 import type { CFXParameters } from '../types';
 
 interface QueryData {
@@ -31,7 +31,7 @@ export const logQuery = (invokingResource: string, query: string, executionTime:
 };
 
 RegisterCommand(
-  'mysql',
+  mysql_ui_command,
   (source: number) => {
     if (!mysql_ui) return;
 


### PR DESCRIPTION
This improves compatibility with mysql-async, since that used the same command name.

Since at the moment I'm running mysql-async and oxmysql side by side while I transition over plugin by plugin.