### PR TITLE
feature(rawQuery): Add event to error handling

### DIFF
--- a/src/database/rawExecute.ts
+++ b/src/database/rawExecute.ts
@@ -77,6 +77,13 @@ export const rawExecute = async (
     .catch((err) => {
       const error = `${invokingResource} was unable to execute a query!\n${err}\n${`${query}`}`;
 
+      TriggerEvent('oxmysql:error', {
+        query: query,
+        parameters: parameters,
+        message: err.message,
+        err: err,
+      });
+
       if (cb && throwError) return cb(null, error);
     throw new Error(error);
     });

--- a/src/database/rawQuery.ts
+++ b/src/database/rawQuery.ts
@@ -28,7 +28,14 @@ export const rawQuery = async (
       } catch (err) {}
     });
   }).catch((err) => {
-    const error = `${invokingResource} was unable to execute a query!\n${err.message}\n${`${query} ${JSON.stringify(parameters)}`}`
+    const error = `${invokingResource} was unable to execute a query!\n${err.message}\n${`${query} ${JSON.stringify(parameters)}`}`;
+
+    TriggerEvent('oxmysql:error', {
+      query: query,
+      parameters: parameters,
+      message: err.message,
+      err: err,
+    });
 
     if (cb && throwError) return cb(null, error);
     throw new Error(error);

--- a/src/database/rawTransaction.ts
+++ b/src/database/rawTransaction.ts
@@ -44,7 +44,7 @@ export const rawTransaction = async (
       }^0`
     );
 
-    TriggerEvent('oxmysql:error', {
+    TriggerEvent('oxmysql:transaction-error', {
       query: transactionErrorMessage,
       parameters: parameters,
       message: (e as Error).message,

--- a/src/database/rawTransaction.ts
+++ b/src/database/rawTransaction.ts
@@ -37,11 +37,19 @@ export const rawTransaction = async (
   } catch (e) {
     await connection.rollback();
 
+    const transactionErrorMessage = (e as any).sql || transactionError(transactions, parameters);
     console.error(
       `${invokingResource} was unable to execute a transaction!\n${(e as Error).message}\n${
-        (e as any).sql || `${transactionError(transactions, parameters)}`
+        transactionErrorMessage
       }^0`
     );
+
+    TriggerEvent('oxmysql:error', {
+      query: transactionErrorMessage,
+      parameters: parameters,
+      message: (e as Error).message,
+      err: e,
+    });
   } finally {
     connection.release();
   }


### PR DESCRIPTION
Adds the possibility to add custom error tracking (ie. Sentry) to sql errors.

I myself use sentry for error tracking, as this allows me to get ahead of issues in the server, and this way it's a very non specific way of implementing this, so you could also add something like discord webhooks, etc etc to this if you'd like.