### PR TITLE
feat(logger): fivemerr support

### DIFF
--- a/logger/fivemerr.js
+++ b/logger/fivemerr.js
@@ -1,0 +1,40 @@
+// https://fivemerr.com
+
+const apiKey = GetConvar("FIVEMERR_LOGS_API_KEY", "");
+
+if (!apiKey) return console.warning(`convar "FIVEMANAGE_LOGS_API_KEY" has not been set`);
+
+const batchedLogs = [];
+const endpoint = 'https://api.fivemerr.com/v1/logs';
+const headers = {
+  ['Content-Type']: 'application/json',
+  ['Authorization']: apiKey,
+  ['User-Agent']: 'oxmysql',
+};
+
+async function sendLogs() {
+  for (let index = 0; index < batchedLogs.length; index++) {
+    try {
+      const body = JSON.stringify(batchedLogs[index]);
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        body: body,
+        headers: headers,
+      });
+
+      if (response.ok) return;
+
+      console.error(`Failed to submit logs to fivemerr - ${response.status} ${response.statusText}`);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  batchedLogs.length = 0;
+}
+
+return function logger(data) {
+  if (batchedLogs.length === 0) setTimeout(sendLogs, 500);
+
+  batchedLogs.push(data);
+};


### PR DESCRIPTION
#### Description
It's been a while since I did anything here although I do still lurk in the issues/pr's, so figured I'd contribute. 

This adds support for logging using <https://fivemerr.com/> as requested in https://github.com/overextended/oxmysql/issues/233. Credit to the requester @rxnm for providing the code (*not sure why they didn't make a PR*). I only made a couple of minor changes to make it mirror the code in the Fivemanage logger.

The code has been tested and is working as intended.

#### Usage:
The logger service is named `fivemerr` and uses a new convar `FIVEMERR_LOGS_API_KEY`.
```
set mysql_logger_service "fivemerr"
set FIVEMERR_LOGS_API_KEY "" # Put your API key here
```