### PR TITLE
Fix(connection/raw query)  handle promise when db connection lost

### DIFF
--- a/src/database/rawExecute.ts
+++ b/src/database/rawExecute.ts
@@ -2,7 +2,7 @@ import { logError, logQuery } from '../logger';
 import { CFXCallback, CFXParameters, QueryType } from '../types';
 import { parseResponse } from '../utils/parseResponse';
 import { executeType, parseExecute } from '../utils/parseExecute';
-import { getConnection } from './connection';
+import { getConnection, MySql } from './connection';
 import { setCallback } from '../utils/setCallback';
 import { performance } from 'perf_hooks';
 import validateResultSet from 'utils/validateResultSet';
@@ -31,9 +31,13 @@ export const rawExecute = async (
     return logError(invokingResource, cb, isPromise, err, query, parameters);
   }
 
-  using connection = await getConnection(connectionId);
-
-  if (!connection) return;
+  let connection: MySql;
+  try {
+    connection = await getConnection(connectionId);
+  } catch (err: any) {
+    if (!cb) return;
+    return logError(invokingResource, cb, isPromise, err, query, parameters, true);
+  }
 
   try {
     const hasProfiler = await runProfiler(connection, invokingResource);

--- a/src/database/rawQuery.ts
+++ b/src/database/rawQuery.ts
@@ -4,7 +4,7 @@ import { parseResponse } from '../utils/parseResponse';
 import { logQuery, logError } from '../logger';
 import type { CFXCallback, CFXParameters } from '../types';
 import type { QueryType } from '../types';
-import { getConnection } from './connection';
+import { getConnection, MySql } from './connection';
 import { RowDataPacket } from 'mysql2';
 import { performance } from 'perf_hooks';
 import validateResultSet from 'utils/validateResultSet';
@@ -26,9 +26,13 @@ export const rawQuery = async (
     return logError(invokingResource, cb, isPromise, err, query, parameters);
   }
 
-  using connection = await getConnection(connectionId);
-
-  if (!connection) return;
+  let connection: MySql;
+  try {
+    connection = await getConnection(connectionId);
+  } catch (err: any) {
+    if (!cb) return;
+    return logError(invokingResource, cb, isPromise, err, query, parameters, true);
+  }
 
   try {
     const hasProfiler = await runProfiler(connection, invokingResource);

--- a/src/database/rawTransaction.ts
+++ b/src/database/rawTransaction.ts
@@ -1,4 +1,4 @@
-import { getConnection } from './connection';
+import { getConnection, MySql } from './connection';
 import { logError, logger, logQuery } from '../logger';
 import { CFXCallback, CFXParameters, TransactionQuery } from '../types';
 import { parseTransaction } from '../utils/parseTransaction';
@@ -28,7 +28,13 @@ export const rawTransaction = async (
     return logError(invokingResource, cb, isPromise, err);
   }
 
-  using connection = await getConnection();
+  let connection: MySql;
+  try {
+    connection = await getConnection();
+  } catch (err: any) {
+    if (!cb) return;
+    return logError(invokingResource, cb, isPromise, err, queries.toString(), parameters, true);
+  }
 
   if (!connection) return;
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -53,8 +53,9 @@ export function logError(
     metadata: err,
   });
 
-  if (cb && isPromise) {
+  if (cb) {
     try {
+      if(isPromise) return cb(null);
       return cb(null, output);
     } catch (e) {}
 


### PR DESCRIPTION
I'm currently developping a gta fivem resource where it could use oxmysql optionnally so I need to check if the database is available or not even after the oxmysql resource is started.
Currently oxmysql do not check if the database is still available after the start while for any reason, the connection can be lost.
Following my tests, I got a promise error not managed which cannot let us handle this case :
![image](https://github.com/user-attachments/assets/71975081-5ef3-470a-b637-b0906eaee165)

After my analysis of your code, I found a quick fix for that which result of this with the test code after:
![image](https://github.com/user-attachments/assets/bceab708-fdd8-4ef2-82b1-fb1bafb56d1f)

Here my sample code for testing db connection :
```lua
local mysqlHost = GetConvar("mysql_connection_string", "")
local mysqlReady = false
if mysqlHost ~= "" then
    Citizen.CreateThread(function()
        ---Verify if MySQL is ready to send to database

        while GetResourceState("oxmysql") ~= "started" or not exports.oxmysql.isReady() do
            Citizen.Wait(30000)
        end
        -- test callback mode
       exports.oxmysql.query(nil, 'SELECT VERSION() as version', {}, function(result, error)
            if error then
                print("MySQL is not ready !")
                mysqlReady = false
            else
                print("MySQL is ready !")
                mysqlReady = true
            end
        end)

        -- test async mode
        local result = exports.oxmysql.query_async(nil, 'SELECT VERSION() as version', {});
        if result then
            print("MySQL async is ready !")
            mysqlReady = true
        else
            print("MySQL async is not ready !")
            mysqlReady = false
        end
    end)
end
```

I don't have a full vision of impact which could happens for other resources so feel free to suggest/review my fix.
Maybe a method to test the real current status of database connection could be great and not only trusting local state.