### PR TITLE
fix(typeCast): TINYINT(1) null handling

### DIFF
--- a/src/utils/typeCast.ts
+++ b/src/utils/typeCast.ts
@@ -41,8 +41,11 @@ export function typeCast(field: TypeCastField, next: TypeCastNext) {
       const value = field.string();
       return value ? new Date(value + ' 00:00:00').getTime() : null;
     }
-    case 'TINY':
-      return field.length === 1 ? field.string() === '1' : next();
+    case 'TINY': {
+      if (field.length !== 1) return next();
+      const value = field.string();
+      return value !== null ? value === '1' : null;
+    }
     case 'BIT':
       return field.length === 1 ? field.buffer()?.[0] === 1 : field.buffer()?.[0];
     case 'TINY_BLOB':


### PR DESCRIPTION
**Problem reproduction**
- Left joining a tinyint(1) field which doesn't have a match returns false

**Expected behaviour**
- Return null