### PR TITLE
fix(logger): guard fetchResource against unknown resource name

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -172,11 +172,15 @@ onNet(
   }) => {
     if (typeof data.resource !== 'string' || !IsPlayerAceAllowed(source as unknown as string, 'command.mysql')) return;
 
+    const storedQueries = logStorage[data.resource];
+
+    if (!storedQueries) return;
+
     if (data.search) data.search = data.search.toLowerCase();
 
     const resourceLog = data.search
-      ? logStorage[data.resource].filter((q) => q.query.toLowerCase().includes(data.search))
-      : logStorage[data.resource];
+      ? storedQueries.filter((q) => q.query.toLowerCase().includes(data.search))
+      : storedQueries;
 
     const sort = data.sortBy && data.sortBy.length > 0 ? data.sortBy[0] : false;
     const startRow = data.pageIndex * 10;


### PR DESCRIPTION
### Problem

The `oxmysql:fetchResource` net handler validates that `data.resource` is a string, but never checks that it actually exists in `logStorage` before indexing it:

```ts
const resourceLog = data.search
  ? logStorage[data.resource].filter((q) => q.query.toLowerCase().includes(data.search))
  : logStorage[data.resource];
```

If `data.resource` is any string that isn't a known resource key, `logStorage[data.resource]` is `undefined` and the `.filter()` call (search branch) throws `Cannot read properties of undefined`. The non-search branch then feeds `undefined` into `resourceLog.slice()` / `resourceLog.length` further down, which throws as well.

This is gated behind `command.mysql`, so it isn't a privilege issue, but a permitted user (or a UI request racing a resource that hasn't logged anything yet) can throw an unhandled exception in the handler.

### Fix

Resolve the log entry once and bail out early when the resource has no stored queries, before any access.
