### PR TITLE
fix(profiler): handle databases that do not support query profiling

### DIFF
--- a/src/database/rawQuery.ts
+++ b/src/database/rawQuery.ts
@@ -8,7 +8,7 @@ import { getConnection } from './connection';
 import { RowDataPacket } from 'mysql2';
 import { performance } from 'perf_hooks';
 import validateResultSet from 'utils/validateResultSet';
-import { runProfiler } from 'profiler';
+import { markProfilerUnsupported, runProfiler } from 'profiler';
 
 export const rawQuery = async (
   type: QueryType,
@@ -36,11 +36,19 @@ export const rawQuery = async (
     const result = await connection.query(query, parameters);
 
     if (hasProfiler) {
-      const profiler = <RowDataPacket[]>(
-        await connection.query('SELECT FORMAT(SUM(DURATION) * 1000, 4) AS `duration` FROM INFORMATION_SCHEMA.PROFILING')
-      );
+      try {
+        const profiler = <RowDataPacket[]>(
+          await connection.query(
+            'SELECT FORMAT(SUM(DURATION) * 1000, 4) AS `duration` FROM INFORMATION_SCHEMA.PROFILING',
+          )
+        );
 
-      if (profiler[0]) logQuery(invokingResource, query, parseFloat(profiler[0].duration), parameters);
+        if (profiler[0]) logQuery(invokingResource, query, parseFloat(profiler[0].duration), parameters);
+      } catch {
+        // Database doesn't actually support INFORMATION_SCHEMA.PROFILING (e.g. TiDB) even though
+        // the SET profiling statements succeeded; stop trying and skip logging this duration.
+        markProfilerUnsupported();
+      }
     } else if (startTime) {
       logQuery(invokingResource, query, performance.now() - startTime, parameters);
     }

--- a/src/profiler/index.ts
+++ b/src/profiler/index.ts
@@ -11,17 +11,50 @@ const profilerStatements = [
   'SET profiling = 1',
 ];
 
+// MySQL/MariaDB support the legacy `SET profiling` / `INFORMATION_SCHEMA.PROFILING`
+// query profiler used below. Other MySQL-protocol-compatible databases (e.g. TiDB)
+// don't implement it, so once it errors we stop attempting it for the remainder of
+// the process rather than failing every subsequent query made while debug logging
+// is enabled.
+let profilerSupported: boolean | undefined;
+
+/**
+ * Marks the profiler as unsupported by the connected database so subsequent calls skip
+ * straight to the fallback timing path instead of re-attempting the MySQL-only statements.
+ */
+export function markProfilerUnsupported() {
+  profilerSupported = false;
+}
+
 /**
  * Executes MySQL queries to enable accurate query profiling results when `mysql_debug` is enabled.
+ * Returns `false` (instead of throwing) if the connected database doesn't support the profiler,
+ * so callers can fall back to plain timing instead of failing the query itself.
  */
 export async function runProfiler(connection: MySql, invokingResource: string) {
   if (!mysql_debug) return;
 
   if (Array.isArray(mysql_debug) && !mysql_debug.includes(invokingResource)) return;
 
-  for (const statement of profilerStatements) await connection.query(statement);
+  if (profilerSupported === false) return false;
 
-  return true;
+  try {
+    for (const statement of profilerStatements) await connection.query(statement);
+
+    profilerSupported = true;
+
+    return true;
+  } catch (err) {
+    if (profilerSupported === undefined) {
+      console.warn(
+        `^3Query profiling is unavailable on this database server (${err instanceof Error ? err.message : err}). Falling back to basic query timing.^0`,
+      );
+    }
+
+    profilerSupported = false;
+
+    return false;
+  }
 }
 
 /**
@@ -34,13 +67,20 @@ export async function profileBatchStatements(
   parameters: CFXParameters | null,
   offset: number,
 ) {
-  const profiler = <RowDataPacket[]>(
-    await connection.query(
-      'SELECT FORMAT(SUM(DURATION) * 1000, 4) AS `duration` FROM INFORMATION_SCHEMA.PROFILING GROUP BY QUERY_ID',
-    )
-  );
+  let profiler: RowDataPacket[];
 
-  for (const statement of profilerStatements) await connection.query(statement);
+  try {
+    profiler = <RowDataPacket[]>(
+      await connection.query(
+        'SELECT FORMAT(SUM(DURATION) * 1000, 4) AS `duration` FROM INFORMATION_SCHEMA.PROFILING GROUP BY QUERY_ID',
+      )
+    );
+
+    for (const statement of profilerStatements) await connection.query(statement);
+  } catch {
+    profilerSupported = false;
+    return;
+  }
 
   if (profiler.length === 0) return;
 


### PR DESCRIPTION
Some MySQL-protocol compatible databases (such as TiDB) accept `SET profiling = 1` statements without error but do not implement the legacy `INFORMATION_SCHEMA.PROFILING` table. Previously, this caused queries to crash when `mysql_debug` was enabled.
This commit introduces a fallback mechanism:
- Adds a `try...catch` block around profiling statements to gracefully handle unsupported databases.
- Introduces a `profilerSupported` state to cache whether the profiler is available. This prevents throwing errors on every subsequent query and instead skips straight to the fallback timing path.
- Logs a warning to the console once to inform the user that query profiling is unavailable and basic query timing will be used instead.